### PR TITLE
Support putting exported variables into global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
       "name": "@ts-defold/tstl-export-as-global",
       "match": ".*script.ts$",
       "globals": { 
-        "functions": [ "init", "on_input", "on_message", "on_reload", "update", "final"]
+        "functions": [ "init", "on_input", "on_message", "on_reload", "update", "final"],
+        "vars": ["who", "what", "where", "when", "why"]
       }
     }
   ]
@@ -20,7 +21,7 @@ The config accpets some additional arguments that are required to make this plug
 - `match`: regex pattern of file names to match to apply export transformations to
 - `globals`: object that defines what to match to apply export transformations to
   - `functions`: array of names to match for export functions to expose as global
-  - `...`: PR welcome for matching constans, variables, etc if you need support.
+  - `vars`: array of names to match for exported variables to expose as global
 
 ## Features
 Transform this TypeScript (with config values from above):

--- a/dist/index.js
+++ b/dist/index.js
@@ -41,9 +41,8 @@ function default_1(options) {
                 }
                 // Gather the exported definitions that have been tagged from the exports tables for methods or variables that match our API
                 printVariableAssignmentStatement(statement) {
-                    statement.left.forEach((leftExpression) => {
-                        if (hasGlobalExportTag(statement) && lua.isTableIndexExpression(leftExpression)) {
-                            const table = leftExpression;
+                    statement.left.forEach((table) => {
+                        if (hasGlobalExportTag(statement) && lua.isTableIndexExpression(table)) {
                             if (lua.isStringLiteral(table.index)) {
                                 this.exportedNames.push(table.index.value);
                             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,24 +3,25 @@ import * as ts from "typescript";
 import * as lua from "typescript-to-lua";
 import { SourceNode } from "source-map";
 
-function addGlobalExportTag(node: tstl.FunctionDefinition) {
+function addGlobalExportTag(node: tstl.Node) {
   Object.assign(node, { __globalExport: true });
 }
 
-function hasGlobalExportTag(node: tstl.FunctionDefinition): boolean {
+function hasGlobalExportTag(node: tstl.Node): boolean {
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   // @ts-ignore
   return node.__globalExport === true;
 }
 
 interface PluginGlobals {
-  functions: Array<string>
+  functions: Array<string>;
+  vars: Array<string>; // Add variable names to be considered for global exports
 }
 
 interface PluginOptions {
-  name: string,
-  match: string,
-  globals: PluginGlobals
+  name: string;
+  match: string;
+  globals: PluginGlobals;
 }
 
 export default function(options: PluginOptions): tstl.Plugin {
@@ -29,34 +30,45 @@ export default function(options: PluginOptions): tstl.Plugin {
   return {
     printer: (program, emitHost, fileName, file) => {
       class Printer extends tstl.LuaPrinter {
-        
-        private exportedMethodNames: Array<string> = [];
+        private exportedNames: Array<string> = [];
 
-        // Gather the exported function definitions that have been tagged from the exports tables for methods that match our API
+        // Gather the exported definitions that have been tagged from the exports tables for methods or variables that match our API
+        public printVariableDeclarationStatement(statement: lua.VariableDeclarationStatement): SourceNode {
+          statement.left.forEach((declaration) => {
+            if (hasGlobalExportTag(declaration)) {
+              this.exportedNames.push(declaration.text);
+            }
+          });
+
+          return super.printVariableDeclarationStatement(statement);
+        }
+
         public printFunctionDefinition(statement: lua.FunctionDefinition): SourceNode {
           if (hasGlobalExportTag(statement) && lua.isTableIndexExpression(statement.left[0])) {
             const table = statement.left[0];
             if (lua.isStringLiteral(table.index)) {
-              this.exportedMethodNames.push(table.index.value);
+              this.exportedNames.push(table.index.value);
             }
           }
 
           return super.printFunctionDefinition(statement);
         }
-        
+
         // Hook the printing of the return to swap it with a block of exports for the API interface (only for matching script types)
         public printReturnStatement(statement: tstl.ReturnStatement): SourceNode {
-          if (tstl.isReturnStatement(statement)) {
-            const expressions = (statement as tstl.ReturnStatement).expressions;
+          if (fileMatcher.test(fileName) && tstl.isReturnStatement(statement)) {
+            const expressions = statement.expressions;
             if (expressions.length > 0 && tstl.isIdentifier(expressions[0])) {
               const identifier = expressions[0] as tstl.Identifier;
-              if (fileMatcher.test(fileName) && identifier.exportable && identifier.text === "____exports") {
-                const injectedStatements = this.exportedMethodNames.map(n => tstl.createAssignmentStatement(tstl.createIdentifier(n), tstl.createIdentifier(`____exports.${n}`)));
+              if (identifier.exportable && identifier.text === "____exports") {
+                const injectedStatements = this.exportedNames.map((n) =>
+                  tstl.createAssignmentStatement(tstl.createIdentifier(n), tstl.createIdentifier(`____exports.${n}`))
+                );
                 return super.printBlock(tstl.createBlock(injectedStatements));
               }
             }
           }
-          
+
           return super.printReturnStatement(statement);
         }
       }
@@ -68,13 +80,26 @@ export default function(options: PluginOptions): tstl.Plugin {
       [ts.SyntaxKind.SourceFile]: (node, context) => {
         const [file] = context.superTransformNode(node) as [tstl.File];
         const statements = file.statements;
-        
-        for (const statement of statements) {
-          if (tstl.isAssignmentStatement(statement) && tstl.isFunctionDefinition(statement) && lua.isTableIndexExpression(statement.left[0])) {
-            const table = statement.left[0];
-            if (lua.isStringLiteral(table.index)) {
-              if (fileMatcher.test(context.sourceFile.fileName) && options.globals.functions.includes(table.index.value)) {
-                addGlobalExportTag(statement);
+
+        if (fileMatcher.test(context.sourceFile.fileName)) {
+          for (const statement of statements) {
+            if (tstl.isVariableDeclarationStatement(statement)) {
+              for (const declaration of statement.left) {
+                if (
+                  tstl.isIdentifier(declaration) &&
+                  options.globals.vars.includes(declaration.text)
+                ) {
+                  addGlobalExportTag(declaration);
+                }
+              }
+            } else if (tstl.isAssignmentStatement(statement) && lua.isTableIndexExpression(statement.left[0])) {
+              const table = statement.left[0];
+              if (lua.isStringLiteral(table.index)) {
+                if (
+                  (options.globals.functions.includes(table.index.value) || options.globals.vars.includes(table.index.value))
+                ) {
+                  addGlobalExportTag(statement);
+                }
               }
             }
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,8 @@ export default function(options: PluginOptions): tstl.Plugin {
 
         // Gather the exported definitions that have been tagged from the exports tables for methods or variables that match our API
         public printVariableAssignmentStatement(statement: tstl.AssignmentStatement): SourceNode {
-          statement.left.forEach((leftExpression) => {
-            if (hasGlobalExportTag(statement) && lua.isTableIndexExpression(leftExpression)) {
-              const table = leftExpression;
+          statement.left.forEach((table) => {
+            if (hasGlobalExportTag(statement) && lua.isTableIndexExpression(table)) {
               if (lua.isStringLiteral(table.index)) {
                 this.exportedNames.push(table.index.value);
               }

--- a/tests/__snapshots__/export-as-global.test.ts.snap
+++ b/tests/__snapshots__/export-as-global.test.ts.snap
@@ -47,6 +47,23 @@ update = ____exports.update
 "
 `;
 
+exports[`handles variables 1`] = `
+"--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
+local ____exports = {}
+local who = \\"BAR\\"
+____exports.what = \\"FOO\\"
+____exports.where = 1000
+____exports.when = function() return 2000 end
+____exports.dontMakeThisGlobal = 3000
+____exports.who = who
+what = ____exports.what
+where = ____exports.where
+when = ____exports.when
+who = ____exports.who
+
+"
+`;
+
 exports[`works with modules 1`] = `
 "--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
 -- Lua Library inline imports

--- a/tests/export-as-global.test.ts
+++ b/tests/export-as-global.test.ts
@@ -28,3 +28,12 @@ it("handles organic returns", async () => {
 	const lua = readFileSync(path.join(__dirname, "out", "tests", "test-return.script.lua"), "utf-8");
     expect(lua).toMatchSnapshot();
 });
+
+it("handles variables", async () => {
+	const result = tstl.transpileProject(path.join(__dirname, "tests.tsconfig.json"));
+	expect(result.diagnostics).toHaveLength(0);
+
+
+	const lua = readFileSync(path.join(__dirname, "out", "tests", "test-var.script.lua"), "utf-8");
+    expect(lua).toMatchSnapshot();
+});

--- a/tests/test-var.script.ts
+++ b/tests/test-var.script.ts
@@ -1,0 +1,11 @@
+const who = 'BAR';
+
+export const what = 'FOO';
+
+export let where = 1000;
+
+export let when = () => 2000;
+
+export const dontMakeThisGlobal = 3000;
+
+export { who };

--- a/tests/tests.tsconfig.json
+++ b/tests/tests.tsconfig.json
@@ -25,7 +25,8 @@
                 "name": "../src/index.ts",
                 "match": ".*script.ts$",
                 "globals": { 
-                    "functions": [ "init", "on_input", "on_message", "on_reload", "update", "final"]
+                    "functions": [ "init", "on_input", "on_message", "on_reload", "update", "final"],
+                    "vars": ["who", "what", "where", "when"]
                 }
             }
         ]


### PR DESCRIPTION
This PR adds support for putting any exported variable into the global scope.

Motivation: I prefer the structure of `export const FOO: TYPE = function() {}` instead of `export function FOO() {}`. It lets me type-check the shape of my functions so I don't put the arguments in the wrong order. 😅

Turns out I still can't use it, since Defold doesn't let you assign `go.property` if you use this syntax. But that's outside the scope of this PR.